### PR TITLE
Fix wrong control id for MiniLab 2 third knob

### DIFF
--- a/src/minilab2/ml2-knob-page.ui
+++ b/src/minilab2/ml2-knob-page.ui
@@ -27,7 +27,7 @@
             <child>
               <object class="Ml2Knob">
                 <property name="title" translatable="yes">Knob 3</property>
-                <property name="control-id-offset">0x03</property>
+                <property name="control-id-offset">0x02</property>
               </object>
             </child>
 


### PR DESCRIPTION
I just noticed this bug while trying to configure my controller