### PR TITLE
add Minilab3 preset name write

### DIFF
--- a/src/minilab3/ml3-book.c
+++ b/src/minilab3/ml3-book.c
@@ -38,6 +38,7 @@ ml3_book_init (Ml3Book *self)
   ArBookClass *scklass = AR_BOOK_GET_CLASS (self);
   scklass->read_control = sc_midi_arturia_v3_read_control;
   scklass->write_control = sc_midi_arturia_v3_write_control;
+  scklass->read_string = sc_midi_arturia_dummy_read_string;
 
   g_type_ensure (ML3_TYPE_CONTROLLER_PAGE);
   g_type_ensure (ML3_TYPE_FADER);

--- a/src/minilab3/ml3-preset-page.ui
+++ b/src/minilab3/ml3-preset-page.ui
@@ -11,6 +11,24 @@
           <object class="ScPreferencesPage">
 
             <child>
+              <object class="AdwPreferencesGroup">
+
+                <child>
+                  <object class="AdwEntryRow">
+                    <child>
+                      <object class="ArControl">
+                        <property name="id">0x203f</property>
+                        <property name="maxlen">16</property>
+                      </object>
+                    </child>
+                    <property name="title" translatable="yes">Name</property>
+                  </object>
+                </child>
+
+              </object>
+            </child>
+
+            <child>
               <object class="ScPreferencesGroup">
                 <child>
                   <object class="AdwSwitchRow">


### PR DESCRIPTION
Minilab3 has the ability of naming the user presets. I do not think  there is a way to retrieve the current preset names from the device, however. This patch adds the widget for naming the preset on the preset page but makes no attempt to read it.
I have tested this change with a Minilab3.