### PR TITLE
nix: add flake to build app

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "SysEx controls for Linux - configure Akai, Arturia and Korg MIDI devices";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "sysex-controls";
+            version = self.shortRev or "dirty";
+
+            src = self;
+
+            nativeBuildInputs = with pkgs; [
+              meson
+              ninja
+              pkg-config
+              wrapGAppsHook4
+              gettext
+              desktop-file-utils
+              appstream-glib
+              glib
+            ];
+
+            buildInputs = with pkgs; [
+              gtk4
+              libadwaita
+              alsa-lib
+            ];
+
+            meta = with pkgs.lib; {
+              description = "SysEx controls for Linux - configure Akai, Arturia and Korg MIDI devices";
+              homepage = "https://github.com/soyersoyer/sysex-controls";
+              license = licenses.gpl3Only;
+              mainProgram = "sysex-controls";
+              platforms = platforms.linux;
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Allows to run the application with `nix run github:soyersoyer/sysex-controls` with nix, the package manager (https://nixos.org/download/).